### PR TITLE
NuCivic/internal#654 As a Content Editor I want to receive an email notification when a new Dataset is added by a Content Author with "Needs Review" moderation state.

### DIFF
--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -435,7 +435,8 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
       $created_node = $this->getDriver()->createNode($node);
 
       // Manage moderation state.
-      workbench_moderation_moderate($created_node, $workbench_moderation_state);
+      // Requires this patch https://www.drupal.org/node/2393771
+      workbench_moderation_moderate($created_node, $workbench_moderation_state, $created_node->uid);
 
       // Add the created node to the datasets array.
       $this->datasets[$created_node->nid] = $created_node;

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -388,6 +388,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     $field_map = array(
       'author' => 'author',
       'title' => 'title',
+      'author' => 'uid',
       'description' => 'body',
       'language' => 'language',
       'tags' => 'field_tags',
@@ -411,11 +412,10 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
           throw new Exception(sprintf("Dataset's field %s doesn't exist, or hasn't been mapped. See FeatureContext::addDatasets for mappings.", $key));
         } else if($key == 'author') {
           $user = user_load_by_name($value);
-          if(!isset($user)) {
-            $value = $user->uid;
+          if($user) {
+            $drupal_field = $field_map[$key];
+            $node->$drupal_field = $user->uid;
           }
-          $drupal_field = $field_map[$key];
-          $node->$drupal_field = $value;
 
         } else if($key == 'tags' || $key == 'publisher') {
           $value = $this->explode_list($value);
@@ -513,7 +513,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     $field_map = array(
       'title' => 'title',
       'description' => 'body',
-      'author' => 'author',
+      'author' => 'uid',
       'language' => 'language',
       'format' => 'field_format',
       'dataset' => 'field_dataset_ref',

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -406,6 +406,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
       // Defaults
       $node->type = 'dataset';
       $node->language = LANGUAGE_NONE;
+      $node->is_new = TRUE;
 
       foreach($datasetHash as $key => $value) {
         if(!isset($field_map[$key])) {
@@ -433,6 +434,17 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
       }
 
       $created_node = $this->getDriver()->createNode($node);
+
+      // Make the node author as the revision author.
+      // This is needed for workbench views filtering.
+      $created_node->log = $created_node->uid;
+      $created_node->revision_uid = $created_node->uid;
+      db_update('node_revision')
+        ->fields(array(
+          'uid' => $created_node->uid,
+        ))
+        ->condition('nid', $created_node->nid, '=')
+        ->execute();
 
       // Manage moderation state.
       // Requires this patch https://www.drupal.org/node/2393771
@@ -569,6 +581,17 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
       }
 
       $created_node = $this->getDriver()->createNode($node);
+
+      // Make the node author as the revision author.
+      // This is needed for workbench views filtering.
+      $created_node->log = $created_node->uid;
+      $created_node->revision_uid = $created_node->uid;
+      db_update('node_revision')
+        ->fields(array(
+          'uid' => $created_node->uid,
+        ))
+        ->condition('nid', $created_node->nid, '=')
+        ->execute();
 
       // Manage moderation state.
       workbench_moderation_moderate($created_node, $workbench_moderation_state);

--- a/tests/features/dataset.author.feature
+++ b/tests/features/dataset.author.feature
@@ -43,8 +43,8 @@ Feature: Dataset Features
       | Dataset 01 | Gabriel | published    | Feb 01, 2015 | Health |
       | Dataset 02 | Gabriel | published    | Mar 13, 2015 | Gov    |
       | Dataset 03 | Katie   | published    | Feb 17, 2013 | Health |
-      | Dataset 04 | Celeste | draft        | Dic 21, 2015 | Gov    |
-      | Dataset 05 | Katie   | needs_review | Dic 21, 2015 | Gov    |
+      | Dataset 04 | Celeste | draft        | Jun 21, 2015 | Gov    |
+      | Dataset 05 | Katie   | needs_review | Jun 21, 2015 | Gov    |
     And "Format" terms:
       | name |
       | csv  |
@@ -116,10 +116,10 @@ Feature: Dataset Features
   Scenario: Request dataset review (Change dataset status from 'Draft' to 'Needs review')
     Given I am logged in as "Celeste"
     And I am on "My drafts" page
-    Then I should see "Dataset 04"
     And I should see "Change to Needs Review" in the "Dataset 04" row
     When I click "Change to Needs Review" in the "Dataset 04" row
-    Then I should see "Needs Review" as "Moderation state" in the "Dataset 04" row
+    Then I should see "Needs Review" in the "Dataset 04" row
+    And user Gabriel should receive an email containing "Please review the recent update at"
 
   @api @wip
   Scenario: Revert review request (Change dataset status from 'Needs review' to 'Draft')


### PR DESCRIPTION
Work done for NuCivic/internal#654

* Add Behat custom steps for emails tests.
* Fix various bugs on bulk node creation with multiple fields.
* Support user attribution when setting moderation state. (require [patching workbench_moderation](https://www.drupal.org/node/2393771). The patch will be included in the sister PR to be submitted to [NuCivic/data_workflow](https://github.com/NuCivic/data_workflow).
* Better node revision handling on bulk node creation.
* Fix and remove "wip" tag from one existing Behat email test related to existing Dataset moderation state change to "Needs Review". 
* Add Behat email test for creating a new Dataset with "Needs Review" moderation state.