### PR TITLE
Enable probo QA sites for data_starter -- Add .probo.yml

### DIFF
--- a/.probo.yml
+++ b/.probo.yml
@@ -1,0 +1,7 @@
+steps:
+  - name: Site Setup
+    plugin: Drupal
+    makeFile: 'build-dkan.make'
+    profileName: 'dkan'
+    runInstall: true
+    clearCaches: true

--- a/.probo.yml
+++ b/.probo.yml
@@ -4,4 +4,5 @@ steps:
     makeFile: 'build-dkan.make'
     profileName: 'dkan'
     runInstall: true
-    clearCaches: true
+  - name: Fix Files Folder Permissions
+    command: 'chmod -R 777 /var/www/html/sites/default/files && drush cc all'


### PR DESCRIPTION
Ref Nucivic/pluto#116

#### Acceptance
- [ ] QA sites are built for data_starter PR and new commits on PRs.